### PR TITLE
Improve usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install tiny-puppeteer
 ## Usage
 
 ```js
-const {launch} = require("tiny-puppeteer");
+const launch = require("tiny-puppeteer");
 const browser = await launch({
   headless: false,
   // executablePath: default is use chrome path


### PR DESCRIPTION
As of version `1.6.0` a function is exported and not an object.

I think it would be nice to return the `puppeteer` object since `puppeteer-core` has the same API as `puppeteer`. Similarly you did it before:

https://github.com/suhaotian/tiny-puppeteer/blob/16fe9ba6beaae438464cd835264f9daebd301bd3/index.js#L8

https://github.com/suhaotian/tiny-puppeteer/blob/16fe9ba6beaae438464cd835264f9daebd301bd3/index.js#L17

https://github.com/suhaotian/tiny-puppeteer/commit/efb8dd9a02f544035d101e28b2a9e7658b6b0ed3#diff-168726dbe96b3ce427e7fedce31bb0bcL8

What do you think?